### PR TITLE
Adds alt tags to img tags that were missing them.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
               {% if current_user %}
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" style="padding: 10px 20px 10px 20px">
-                    <img src="{{ current_user['profile_image_url'] }}" width="30" height="30">
+                    <img alt="" src="{{ current_user['profile_image_url'] }}" width="30" height="30">
                     <span class="caret"></span>
                   </a>
                   <ul class="dropdown-menu" role="menu">

--- a/templates/event.html
+++ b/templates/event.html
@@ -46,7 +46,7 @@
     {% end %}
     
     <div class="avatar">
-      <a href="/user/{{ event['creator_user_id'] }}"><img src="{{ creator['profile_image_url'] }}" class="img-rounded" style="float: left"></a>
+      <a href="/user/{{ event['creator_user_id'] }}"><img alt="" src="{{ creator['profile_image_url'] }}" class="img-rounded" style="float: left"></a>
       <strong><a href="/user/{{ event['creator_user_id'] }}">{{ creator['name'] }}</a> @{{ creator['screen_name'] }}</strong><br />
       {{ arrow.get( event['created_at'] ).humanize() }}
     </div>
@@ -59,7 +59,7 @@
         {% for watchlist in event['watchlists'] %}
           {% if watchlist['status'] == 'watch' %}
             <li>
-              <a href="/user/{{ watchlist['user_id'] }}"><img src="{{ watchlist['avatar'] }}"></a> 
+              <a href="/user/{{ watchlist['user_id'] }}"><img alt="" src="{{ watchlist['avatar'] }}"></a> 
               <a href="/user/{{ watchlist['user_id'] }}">{{ watchlist['username'] }}</a>
             </li>
           {% end %}
@@ -70,7 +70,7 @@
         {% for watchlist in event['watchlists'] %}
           {% if watchlist['status'] == 'attend' %}
             <li>
-              <a href="/user/{{ watchlist['user_id'] }}"><img src="{{ watchlist['avatar'] }}"></a>
+              <a href="/user/{{ watchlist['user_id'] }}"><img alt="" src="{{ watchlist['avatar'] }}"></a>
               <a href="/user/{{ watchlist['user_id'] }}">{{ watchlist['username'] }}</a>
             </li>
           {% end %}
@@ -84,7 +84,7 @@
     <h3>Comments</h3><br />
       {% for comment in event['comments'] %}
         <li>
-          <a href="/user/@{{ comment['username'] }}"><img src="{{ comment['avatar'] }}"></a> 
+          <a href="/user/@{{ comment['username'] }}"><img alt="" src="{{ comment['avatar'] }}"></a> 
           <a href="/user/@{{ comment['username'] }}">{{ comment['name'] }}</a> @{{ comment['username'] }}:
           {{ comment['comment'] }}
         </li>

--- a/templates/user.html
+++ b/templates/user.html
@@ -3,7 +3,7 @@
 {% block body %}
 
   <h3>
-    <a href="http://twitter.com/{{ user['screen_name'] }}"><img src="{{ user['profile_image_url'] }}" style="float: left; margin-right: 10px;"></a>
+    <a href="http://twitter.com/{{ user['screen_name'] }}"><img alt="" src="{{ user['profile_image_url'] }}" style="float: left; margin-right: 10px;"></a>
     {{ user['name'] }} <small>@{{ user['screen_name'] }}</small>
   </h3>
   


### PR DESCRIPTION
This just adds an empty "alt" attribute on <img> tags, so screen readers won't read out the janky file path / file name. In each of these cases, there's a link nearby to the profile's page, using the profile name as the text of the link. So it's okay (preferred, even) for screen readers to silently drop these links.
