### PR TITLE
Set end date

### DIFF
--- a/views/add.jade
+++ b/views/add.jade
@@ -58,7 +58,7 @@ block content
       input#postal_code(type='hidden', name='postal_code')
       input#longitude(type='hidden', name='longitude')
       input#latitude(type='hidden', name='latitude')
-  
+
   script.
     var venues = new Bloodhound({
       datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
@@ -74,9 +74,9 @@ block content
         rateLimitWait: 250,
       }
     });
-    
+
     venues.initialize();
-    
+
     $('#name').typeahead({
         hint: true,
         highlight: false,
@@ -97,7 +97,7 @@ block content
         }
       }
     ).on('typeahead:selected', onSelected);
-    
+
     function onSelected($e, venue) {
       $('#foursquare_id').val(venue['id']);
       $('#address').val(venue['location']['address']);
@@ -107,7 +107,7 @@ block content
       $('#longitude').val(venue['location']['lng']);
       $('#latitude').val(venue['location']['lat']);
     }
-    
+
     $("#city").geocomplete({
       types: ['(cities)']
     });

--- a/views/add.jade
+++ b/views/add.jade
@@ -111,3 +111,11 @@ block content
     $("#city").geocomplete({
       types: ['(cities)']
     });
+
+    var end_date_changed = false;
+    $('#end_date').on('change', function(){end_date_changed=true;});
+    $('#start_date').on('change', function(){
+      if (end_date_changed !== true) {
+        $('#end_date').val($('#start_date').val());
+      }
+    });


### PR DESCRIPTION
Some whitespace cleanup makes it tricker to spot the actual change, which is here: https://github.com/revdancatt/upcoming-www/commit/195ebd6f235d8173d516faa586f0ec85ad92a291

![caledit](https://cloud.githubusercontent.com/assets/83807/24664103/a83910d8-1951-11e7-867e-df7131464ab4.gif)

This sets the end date calendar to match the start date when the start date is set or updated. However, if the user edits the end date by hand then further updating the start date will _not_ modify the end date. This is to keep a balance between helping the user, and not stomping over their manual selection.

This is to answer issues: #33 and #23 

*Note* This is on `add.jade` only, not `edit.jade` as it's assumed we only want the helper when first picking the dates, after that we're modifying the users already entered data.