### PR TITLE
select comment.created_at

### DIFF
--- a/models/comment.js
+++ b/models/comment.js
@@ -16,7 +16,7 @@ exports.create = function(user, comment, next) {
 
 /* find comments by event id */
 exports.getAllByEventId = function(event_id, next) {
-  var sql = 'SELECT *, comment.created_at FROM comment, user '
+  var sql = 'SELECT *, comment.id, comment.created_at FROM comment, user '
       + 'WHERE comment.user_id = user.id '
       + 'AND comment.event_id = ?';
   db.query(sql, event_id, function (err, rows) {

--- a/models/comment.js
+++ b/models/comment.js
@@ -16,7 +16,7 @@ exports.create = function(user, comment, next) {
 
 /* find comments by event id */
 exports.getAllByEventId = function(event_id, next) {
-  var sql = 'SELECT * FROM comment, user '
+  var sql = 'SELECT *, comment.created_at FROM comment, user '
       + 'WHERE comment.user_id = user.id '
       + 'AND comment.event_id = ?';
   db.query(sql, event_id, function (err, rows) {


### PR DESCRIPTION
The `SELECT * FROM comment, user` query was resulting in the `user.created_at` field being found when trying to show the comment's `created_at`. This change overrides the `created_at` result to select from the comment table instead.